### PR TITLE
Secure and improve LemonFacturX module

### DIFF
--- a/class/actions_lemonfacturx.class.php
+++ b/class/actions_lemonfacturx.class.php
@@ -67,13 +67,21 @@ class ActionsLemonFacturX
 		file_put_contents($xmlTmpFile, $xml);
 
 		// Injection via process séparé pour éviter le conflit FPDF/TCPDF
+		if (!function_exists('exec')) {
+			$this->error = 'LemonFacturX: exec() function is disabled';
+			dol_syslog($this->error, LOG_ERR);
+			@unlink($xmlTmpFile);
+			return 0;
+		}
+
+		$phpCmd = defined('PHP_BINARY') ? PHP_BINARY : 'php';
 		$scriptPath = escapeshellarg($modulePath.'/lib/inject_facturx.php');
 		$pdfArg = escapeshellarg($file);
 		$xmlArg = escapeshellarg($xmlTmpFile);
 
 		$output = [];
 		$returnCode = 0;
-		exec("php $scriptPath $pdfArg $xmlArg 2>&1", $output, $returnCode);
+		exec(escapeshellarg($phpCmd)." $scriptPath $pdfArg $xmlArg 2>&1", $output, $returnCode);
 
 		@unlink($xmlTmpFile);
 

--- a/lib/inject_facturx.php
+++ b/lib/inject_facturx.php
@@ -16,6 +16,11 @@
  * TCPDF (utilisé par Dolibarr).
  */
 
+if (php_sapi_name() !== 'cli') {
+	http_response_code(403);
+	exit;
+}
+
 if ($argc < 3) {
 	fwrite(STDERR, "Usage: php inject_facturx.php <pdf_path> <xml_path>\n");
 	exit(1);


### PR DESCRIPTION
Secured the LemonFacturX module by restricting `lib/inject_facturx.php` to CLI execution and improving the `exec` call in `class/actions_lemonfacturx.class.php` to use `PHP_BINARY` and check for availability.

---
*PR created automatically by Jules for task [14239557236242871107](https://jules.google.com/task/14239557236242871107) started by @hello-lemon*